### PR TITLE
Add prospector-mirror

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -9,3 +9,4 @@
 - git://github.com/FalconSocial/pre-commit-python-sorter
 - git://github.com/guykisel/pre-commit-robotframework-tidy
 - git://github.com/FalconSocial/pre-commit-mirrors-pep257
+- git://github.com/guykisel/prospector-mirror


### PR DESCRIPTION
In landscapeio/prospector#78, Prospector was updated to allow multiple command line file inputs, which makes it easy to create a pre-commit hook for Prospector. The hook is configured to run as a system hook rather than a python hook to allow pylint to validate imports.

https://github.com/guykisel/prospector-mirror