### PR TITLE
Add chriskuehl/puppet-pre-commit-hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -20,3 +20,4 @@
 - git://github.com/hyperNURb/mirrors-jscs
 - git://github.com/Lucas-C/pre-commit-hooks
 - git://github.com/SamWhited/go-pre-commit
+- git://github.com/chriskuehl/puppet-pre-commit-hooks


### PR DESCRIPTION
https://github.com/chriskuehl/puppet-pre-commit-hooks

3 hooks:

* puppet-validate: uses `puppet parser validate` to validate manifests
* erb-validate: compiles erb templates and checks them with `ruby -c`
* puppet-lint

The last obviously overlaps with the puppet-lint mirror, but it seems reasonable to keep these three in one repo.