### PR TITLE
Change Go hooks to new BitBucket URL

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -19,5 +19,5 @@
 - git://github.com/pricematch/pricematch-pre-commit-hooks
 - git://github.com/hyperNURb/mirrors-jscs
 - git://github.com/Lucas-C/pre-commit-hooks
-- git://github.com/SamWhited/go-pre-commit
+- https://bitbucket.org/SamWhited/go-pre-commit.git
 - git://github.com/chriskuehl/puppet-pre-commit-hooks


### PR DESCRIPTION
I'm moving this [linked repo](https://github.com/SamWhited/go-pre-commit) to [BitBucket](https://bitbucket.org/SamWhited/go-pre-commit). I will remove the GitHub version shortly.