### PR TITLE
Adding golang hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -22,3 +22,4 @@
 - https://bitbucket.org/SamWhited/go-pre-commit.git
 - git://github.com/chriskuehl/puppet-pre-commit-hooks
 - git://github.com/elidupuis/mirrors-standard
+- git://github.com/dnephin/pre-commit-golang


### PR DESCRIPTION
I looked at the SamWhited/go-pre-commit.git hooks, but they don't quite work for larger repos (`go vet` fails if you pass it files from multiple packages, the `go fmt` hook hides all output) so I created these.

