### PR TITLE
Corrected documentation: YAML array items do not need quotes

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -248,7 +248,7 @@
             <p>As of version 0.3.5, pre-commit can be used to manage <code>pre-push</code> hooks.  Simply <code>pre-commit install --hook-type pre-push</code>.</p>
 
             <h2 id="confining-hooks-to-run-at-certain-stages">Confining hooks to run at certain stages</h2>
-            <p>If pre-commit during push has been installed, then all hooks (by default) will be run during the <code>push</code> stage. Hooks can however be confined to a stage by setting the <code>stages</code> property in your <code>.pre-commit-config.yaml</code>. The <code>stages</code> property is an array and can be set to either <code>['commit']</code>, <code>['push']</code> or <code>['commit','push']</code>.</p>
+            <p>If pre-commit during push has been installed, then all hooks (by default) will be run during the <code>push</code> stage. Hooks can however be confined to a stage by setting the <code>stages</code> property in your <code>.pre-commit-config.yaml</code>. The <code>stages</code> property is an array and can be set to either <code>[commit]</code>, <code>[push]</code> or <code>[commit,push]</code>.</p>
 
             <h2>Passing arguments to hooks</h2>
             <p>Sometimes hooks require arguments to run correctly. You can pass static arguments by specifying the <code>args</code> property in your <code>.pre-commit-config.yaml</code> as follows:</p>


### PR DESCRIPTION
When I originally wrote this documentation, it was late at night (classic excuse) and I included quotes for the YAML array items. The documentation is corrected here.