### PR TITLE
Add repo with pre-commit hooks for R

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -30,3 +30,4 @@
 - git://github.com/jordant/rubocop-pre-commit-hook
 - git://github.com/jstewmon/check-swagger
 - git://github.com/detailyang/pre-commit-shell
+- https://github.com/sanmai-NL/pre-commit-hooks_R


### PR DESCRIPTION
Currently, [`lintr`](https://github.com/jimhester/lintr) is supported. The hook has been tested (against tag `0.1.0`) with success on an R package in development.