### PR TITLE
added magicmark/pre-commit-es6-imports-reorder

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -31,3 +31,4 @@
 - git://github.com/jstewmon/check-swagger
 - git://github.com/detailyang/pre-commit-shell
 - git://github.com/sanmai-NL/pre-commit-hooks_R
+- git://github.com/magicmark/pre-commit-es6-imports-reorder


### PR DESCRIPTION
pre-commit hook for reordering ES6 import statements

Verified as working locally, working on adding tests.