### PR TITLE
Add pydocstyle hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -41,3 +41,4 @@
 - git://github.com/antonbabenko/pre-commit-terraform
 - git://github.com/willthames/ansible-lint
 - git://github.com/doublify/pre-commit-clang-format
+- git://github.com/chewse/pre-commit-mirrors-pydocstyle


### PR DESCRIPTION
Seems that github.com/FalconSocial/pre-commit-mirrors-pep257 hasn't been updated in a year and for `pydocstyle` so this repo exists.