### PR TITLE
Some updates:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.5
+python: 3.6
 install: pip install virtualenv --upgrade
 script: make
 after_success: ./push_to_gh.sh
@@ -8,7 +8,6 @@ branches:
         - master
 env:
     global:
-        - GH_REF: github.com/pre-commit/pre-commit.github.io.git
         # GH_TOKEN
         - secure: nNgNYmtwXquPRuAFi/6kXOVjSYroglxuIjvZHDun5eCYikV1KgvXM1Q9Yh3CWgNmIWG1LKt76nt/5u4tLleJiZ7AbjcmLMb9dw7679jFNaDd14tIGyWyYBzrqfqxnayTNLclcfp59l0Yi3ag1i7z4J94LM+7tp8D4jr7RyLd++I=
 sudo: false

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ index.html hooks.html: venv all-hooks.json base.mako index.mako hooks.mako make_
 
 venv: requirements-dev.txt Makefile
 	rm -rf venv
-	virtualenv venv -ppython3.5
+	virtualenv venv -ppython3.6
 	venv/bin/pip install -r requirements-dev.txt
 
 nenv: venv

--- a/index.mako
+++ b/index.mako
@@ -57,7 +57,10 @@
             <p>Before you can run hooks, you need to have the pre-commit package manager installed.</p>
             <p>Using pip:</p>
             <pre>pip install pre-commit</pre>
-            <p>Non Administrative Installation:</p>
+            <p>
+                Non Administrative Installation:
+                <small><em>(To upgrade: run again, to uninstall: pass <code>uninstall</code> to python)</em></small>
+            </p>
             <pre>curl http://pre-commit.com/install-local.py | python</pre>
             <p>System Level Install:</p>
             <pre>curl https://bootstrap.pypa.io/get-pip.py | sudo python - pre-commit</pre>

--- a/install-local.py
+++ b/install-local.py
@@ -19,15 +19,16 @@ else:
 
 
 TGZ = (
-    'https://pypi.python.org/packages/source/v/virtualenv/'
-    'virtualenv-1.11.6.tar.gz'
+    'https://pypi.python.org/packages/d4/0c/'
+    '9840c08189e030873387a73b90ada981885010dd9aea134d6de30cd24cb8/'
+    'virtualenv-15.1.0.tar.gz'
 )
 PKG_PATH = '/tmp/.virtualenv-pkg'
 
 
-def clean():
-    if os.path.exists(PKG_PATH):
-        shutil.rmtree(PKG_PATH)
+def clean(dirname):
+    if os.path.exists(dirname):
+        shutil.rmtree(dirname)
 
 
 @contextlib.contextmanager
@@ -35,11 +36,12 @@ def clean_path():
     try:
         yield
     finally:
-        clean()
+        clean(PKG_PATH)
 
 
 def virtualenv(path):
-    clean()
+    clean(PKG_PATH)
+    clean(path)
 
     print('Downloading ' + TGZ)
     tar_contents = io.BytesIO(urlopen(TGZ).read())
@@ -60,15 +62,24 @@ def virtualenv(path):
 
 def main():
     venv_path = os.path.join(os.environ['HOME'], '.pre-commit-venv')
+    bin_dir = os.path.join(os.environ['HOME'], 'bin')
+    script_src = os.path.join(venv_path, 'bin', 'pre-commit')
+    script_dest = os.path.join(bin_dir, 'pre-commit')
+
+    if sys.argv[1:] == ['uninstall']:
+        clean(PKG_PATH)
+        clean(venv_path)
+        if os.path.lexists(script_dest):
+            os.remove(script_dest)
+        print('Cleaned ~/.pre-commit-venv ~/bin/pre-commit')
+        return 0
+
     virtualenv(venv_path)
 
     subprocess.check_call((
         os.path.join(venv_path, 'bin', 'pip'), 'install', 'pre-commit',
     ))
 
-    bin_dir = os.path.join(os.environ['HOME'], 'bin')
-    script_src = os.path.join(venv_path, 'bin', 'pre-commit')
-    script_dest = os.path.join(bin_dir, 'pre-commit')
     print('*' * 79)
     print('Installing pre-commit to {0}'.format(script_dest))
     print('*' * 79)

--- a/make_all_hooks.py
+++ b/make_all_hooks.py
@@ -8,7 +8,7 @@ import subprocess
 import tempfile
 
 import aspy.yaml
-from pre_commit.clientlib.validate_manifest import load_manifest
+from pre_commit.clientlib import load_manifest
 
 
 def get_manifest_from_repo(repo_path):

--- a/push_to_gh.sh
+++ b/push_to_gh.sh
@@ -2,11 +2,11 @@
 
 [ "$TRAVIS_BRANCH" == "real_master" -a "$TRAVIS_PULL_REQUEST" == "false" ] || exit
 
-git clone "https://${GH_TOKEN}@${GH_REF}" out >& /dev/null
+git clone "https://${GH_TOKEN}@$github.com/${TRAVIS_REPO_SLUG}" out >& /dev/null
 cd out
 git checkout master
 git config user.name "Travis-CI"
-git config user.email "kstruys@yelp.com"
+git config user.email "user@example.com"
 # Repo
 cp ../CNAME ../.travis.yml .
 # Website

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ aspy.yaml
 mako
 libsass
 nodeenv
-pre-commit>=0.13.1
+pre-commit>=0.13.6


### PR DESCRIPTION
- Use python3.6
- Upgrade virtualenv in non-administrative install
- Implement uninstall in non-administrative install
- Implement upgrade in non-administrative install
- Mention how to uninstall / upgrade non-administrative install
  Resolves pre-commit/pre-commit#512
- Update make_all_hooks.py for pre-commit 0.13.6
- Simplify push_to_gh.sh

Didn't really mean for this to be a megabranch / megacommit -- one thing led to another and I got carried away :)