### PR TITLE
Fix typo

### DIFF
--- a/base.mako
+++ b/base.mako
@@ -30,7 +30,7 @@
                         <li><a href="https://github.com/pre-commit/demo-repo#readme">Demo</a></li>
                     </ul>
                     <ul class="nav navbar-nav navbar-right">
-                        <li><a href="https://github.com/pre-commit/pre-commit" class="btn btn-default">Download on Github</a></li>
+                        <li><a href="https://github.com/pre-commit/pre-commit" class="btn btn-default">Download on GitHub</a></li>
                     </ul>
                 </nav>
             </div>

--- a/base.mako
+++ b/base.mako
@@ -51,7 +51,7 @@
             <p><iframe src="http://ghbtns.com/github-btn.html?user=pre-commit&amp;repo=pre-commit&amp;type=watch&amp;count=true"
   allowtransparency="true" frameborder="0" scrolling="0" width="104px" height="20"></iframe>
 <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://pre-commit.com" data-text="pre-commit - A framework for managing and maintaining multi-language pre-commit hooks.">Tweet</a>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></p>   
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></p>
         </div>
         </div>
         <div class="container pc-main-content">

--- a/index.mako
+++ b/index.mako
@@ -243,7 +243,7 @@
                 host.  For configuring Docker hooks, your <code>entry</code>
                 should correspond to an executable inside the Docker
                 container, and will be used to override the default container
-                entrypoint. Your Docker <code>CMD</code> will not run when 
+                entrypoint. Your Docker <code>CMD</code> will not run when
                 pre-commit passes a file list as arguments to the run
                 container  command. Docker allows you to use any language
                 that's not supported by pre-commit as a builtin.
@@ -354,7 +354,7 @@
             <h3 id="script">script</h3>
             <p>
                 Script hooks provide a way to write simple scripts which
-                valdiate files. The <code>entry</code> should be a path 
+                valdiate files. The <code>entry</code> should be a path
                 relative to the root of the hook repository.
             </p>
             <p>


### PR DESCRIPTION
It's GitHub, not Github. ;-)
This PR also fixes a couple of whitespace errors (in a separate commit).