### PR TITLE
Disable jekyll to get js back

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ push: venv
 	venv/bin/markdown-to-presentation push \
 		--master-branch real_master \
 		--pages-branch master \
-		.travis.yml README.md CNAME \
+		.nojekyll .travis.yml README.md CNAME \
 		build node_modules *.html *.png favicon.ico \
 		all-hooks.json install-local.py
 


### PR DESCRIPTION
bootstrap.min.js is 404ing, [this article](https://www.bennadel.com/blog/3181-including-node-modules-and-vendors-folders-in-your-github-pages-site.htm) implies I should add a .nojekyll file (might as well try it, why not).