### PR TITLE
Disable hooks which do not provide .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,22 +2,15 @@
     sha: v0.9.1
     hooks:
     -   id: trailing-whitespace
-        language_version: python3.5
     -   id: end-of-file-fixer
-        language_version: python3.5
     -   id: autopep8-wrapper
-        language_version: python3.5
     -   id: check-yaml
-        language_version: python3.5
     -   id: debug-statements
-        language_version: python3.5
     -   id: flake8
-        language_version: python3.5
 -   repo: https://github.com/asottile/reorder_python_imports.git
     sha: v0.3.4
     hooks:
     -   id: reorder-python-imports
-        language_version: python3.5
 -   repo: local
     hooks:
     -   id: scss-lint

--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -13,19 +13,23 @@
 - git://github.com/pre-commit/mirrors-yapf
 - git://github.com/FalconSocial/pre-commit-mirrors-pep257
 - git://github.com/FalconSocial/pre-commit-python-sorter
-- git://github.com/guykisel/pre-commit-robotframework-tidy
+# https://github.com/guykisel/pre-commit-robotframework-tidy/issues/1
+# - git://github.com/guykisel/pre-commit-robotframework-tidy
 - git://github.com/guykisel/prospector-mirror
 - git://github.com/asottile/add-trailing-comma
 - git://github.com/asottile/pyupgrade
 - git://github.com/asottile/reorder_python_imports
 - git://github.com/asottile/cheetah_lint
-- git://github.com/hootsuite/pre-commit-php
+# https://github.com/hootsuite/pre-commit-php/issues/16
+# - git://github.com/hootsuite/pre-commit-php
 - git://github.com/pricematch/mirrors-rubocop
-- git://github.com/pricematch/mirrors-closure-linter
+# https://github.com/pricematch/mirrors-closure-linter/issues/1
+# - git://github.com/pricematch/mirrors-closure-linter
 - git://github.com/pricematch/pricematch-pre-commit-hooks
 - git://github.com/elidupuis/mirrors-jscs
 - git://github.com/elidupuis/mirrors-sass-lint
-- git://github.com/elidupuis/mirrors-standard
+# https://github.com/elidupuis/mirrors-standard/issues/2
+# - git://github.com/elidupuis/mirrors-standard
 - git://github.com/Lucas-C/pre-commit-hooks
 - git://github.com/Lucas-C/pre-commit-hooks-bandit
 - git://github.com/Lucas-C/pre-commit-hooks-go
@@ -37,11 +41,14 @@
 - git://github.com/chriskuehl/puppet-pre-commit-hooks
 - git://github.com/dnephin/pre-commit-golang
 - git://github.com/troian/pre-commit-golang.git
-- git://github.com/jordant/rubocop-pre-commit-hook
+# https://github.com/jordant/rubocop-pre-commit-hook/issues/4
+# - git://github.com/jordant/rubocop-pre-commit-hook
 - git://github.com/jstewmon/check-swagger
 - git://github.com/detailyang/pre-commit-shell
-- git://github.com/sanmai-NL/pre-commit-hooks_R
-- git://github.com/magicmark/pre-commit-es6-imports-reorder
+# https://github.com/sanmai-NL/pre-commit-hooks_R/issues/1
+# - git://github.com/sanmai-NL/pre-commit-hooks_R
+# https://github.com/magicmark/pre-commit-es6-imports-reorder/issues/1
+# - git://github.com/magicmark/pre-commit-es6-imports-reorder
 - git://github.com/antonbabenko/pre-commit-terraform
 - git://github.com/willthames/ansible-lint
 - git://github.com/doublify/pre-commit-clang-format

--- a/make_all_hooks.py
+++ b/make_all_hooks.py
@@ -1,8 +1,6 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import collections
 import json
+import multiprocessing
 import os.path
 import subprocess
 import tempfile
@@ -11,26 +9,21 @@ import aspy.yaml
 from pre_commit.clientlib import load_manifest
 
 
-def get_manifest_from_repo(repo_path):
+def get_manifest(repo_path):
+    print(f'*** {repo_path}')
     with tempfile.TemporaryDirectory() as directory:
         repo_dir = os.path.join(directory, 'repo')
-        subprocess.call(('git', 'clone', repo_path, repo_dir))
+        subprocess.call(('git', 'clone', '-q', repo_path, repo_dir))
         manifest_path = os.path.join(repo_dir, '.pre-commit-hooks.yaml')
-        manifest_path_legacy = os.path.join(repo_dir, 'hooks.yaml')
-        if os.path.exists(manifest_path):
-            path = manifest_path
-        else:
-            path = manifest_path_legacy
         # Validate the manifest just to make sure it's ok.
-        load_manifest(path)
-        return aspy.yaml.ordered_load(open(path))
+        load_manifest(manifest_path)
+        return (repo_path, aspy.yaml.ordered_load(open(manifest_path)))
 
 
 def main():
     repos = aspy.yaml.ordered_load(open('all-repos.yaml'))
-    hooks_json = collections.OrderedDict()
-    for repo in repos:
-        hooks_json[repo] = get_manifest_from_repo(repo)
+    pool = multiprocessing.Pool(4)
+    hooks_json = collections.OrderedDict(pool.map(get_manifest, repos))
 
     with open('all-hooks.json', 'w') as hooks_json_file:
         json.dump(hooks_json, hooks_json_file, indent=4)

--- a/make_templates.py
+++ b/make_templates.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import collections
 import json
 import os.path


### PR DESCRIPTION
In 0.16.0, pre-commit has stopped reading the legacy `hooks.yaml` file and is
instead reading only `.pre-commit-hooks.yaml`.

The following issues track getting this updated / fixed:
- https://github.com/guykisel/pre-commit-robotframework-tidy/issues/1
- https://github.com/hootsuite/pre-commit-php/issues/16
- https://github.com/pricematch/mirrors-closure-linter/issues/1
- https://github.com/elidupuis/mirrors-standard/issues/2
- https://github.com/jordant/rubocop-pre-commit-hook/issues/4
- https://github.com/sanmai-NL/pre-commit-hooks_R/issues/1
- https://github.com/magicmark/pre-commit-es6-imports-reorder/issues/1