### PR TITLE
Remove pricematch mirrors and hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -21,9 +21,6 @@
 - git://github.com/asottile/reorder_python_imports
 - git://github.com/asottile/cheetah_lint
 - git://github.com/digitalpulp/pre-commit-php
-- git://github.com/pricematch/mirrors-rubocop
-- git://github.com/pricematch/mirrors-closure-linter
-- git://github.com/pricematch/pricematch-pre-commit-hooks
 - git://github.com/elidupuis/mirrors-jscs
 - git://github.com/elidupuis/mirrors-sass-lint
 # https://github.com/elidupuis/mirrors-standard/issues/2


### PR DESCRIPTION
Hi,

We've received a PR on one of those mirrors https://github.com/pricematch/mirrors-rubocop/pull/3, we're actually not maintaining them anymore, and they've become pretty obsolete with support for local hooks in other languages.