### PR TITLE
Document the fact that the hook's name can be overriden

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -171,6 +171,9 @@ repository's configuration.
     =c= `id`
     =c= which hook from the repository to use.
 =r=
+    =c= `name`
+    =c= (optional) override the name of the hook - shown during hook execution.
+=r=
     =c= `language_version`
     =c= (optional) override the language version for the
         hook.  See [Overriding Language Version](#overriding-language-version).


### PR DESCRIPTION
Just realized that it was possible to override the name of a hook. I think it's an interesting feature, so I thought I'd document it.