### PR TITLE
Fix `local` anchor link

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -425,7 +425,7 @@ _new in 0.18.0_
 A more lightweight approach to `docker` hooks.  The `docker_image`
 "language" uses existing docker images to provide hook executables.
 
-`docker_image` hooks can be conveniently configured as [local](#repository-local)
+`docker_image` hooks can be conveniently configured as [local](#repository-local-hooks)
 hooks.
 
 The `entry` specifies the docker tag to use.  If an image has an


### PR DESCRIPTION
Fixes a link that was pointed at an anchor that didn't exist.