### PR TITLE
Added pip-compile-multi

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -78,3 +78,4 @@
 - https://github.com/motet-a/jinjalint
 - https://github.com/milin/giticket
 - https://github.com/sqlalchemyorg/zimports
+- https://github.com/peterdemin/pip-compile-multi


### PR DESCRIPTION
Caters for verifying that pip-compile-multi has been run after changing (multiple) requirements.in files

[pip-compile-multi](https://github.com/peterdemin/pip-compile-multi) allows to benefit from [pip-tools'](https://github.com/jazzband/pip-tools) dependency locking for requirements files combined with the possibility to break them down (eg. `base`, `dev`, `prod`, `test`)