### PR TITLE
Add Reference to `noeval`

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -79,3 +79,4 @@
 - https://github.com/milin/giticket
 - https://github.com/sqlalchemyorg/zimports
 - https://github.com/peterdemin/pip-compile-multi
+- https://github.com/brianjbuck/noeval


### PR DESCRIPTION
Adds a hook to disallow `eval()` in code: 
-  https://github.com/brianjbuck/noeval