### PR TITLE
Add pre-commit-macadmin

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -81,3 +81,4 @@
 - https://github.com/milin/giticket
 - https://github.com/sqlalchemyorg/zimports
 - https://github.com/peterdemin/pip-compile-multi
+- https://github.com/homebysix/pre-commit-macadmin


### PR DESCRIPTION
This repo includes special validation for a few file types commonly used by Mac-centric IT professionals.