### PR TITLE
Add pre-commit-luacheck hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -84,3 +84,4 @@
 - https://github.com/homebysix/pre-commit-macadmin
 - https://github.com/fortman/pre-commit-prometheus
 - https://github.com/syntaqx/git-hooks
+- https://github.com/Calinou/pre-commit-luacheck


### PR DESCRIPTION
This adds a hook that runs [Luacheck](https://luacheck.readthedocs.io/en/stable/) on Lua files.