### PR TITLE
Add the official hook from the golangci-lint project

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -39,6 +39,7 @@
 - https://github.com/Lucas-C/pre-commit-hooks-nodejs
 - https://github.com/Lucas-C/pre-commit-hooks-safety
 - https://github.com/chriskuehl/puppet-pre-commit-hooks
+- https://github.com/golangci/golangci-lint
 - https://github.com/dnephin/pre-commit-golang
 - https://github.com/troian/pre-commit-golang
 - https://github.com/jstewmon/check-swagger


### PR DESCRIPTION
Both myself and @dnephin had implementations of golangci-lint - However, they've had an official one for [some time now](https://github.com/golangci/golangci-lint/blob/master/.pre-commit-hooks.yaml) - I've sunset mine in my most recent version, and added this so that we can prevent duplication and work and try to get people to use & support the one from the project.