### PR TITLE
Added pre-commit-cpp to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -97,3 +97,4 @@
 - https://github.com/myint/docformatter
 - https://github.com/lorenzwalthert/pre-commit-hooks
 - https://github.com/FelixSeptem/pre-commit-golang
+- https://gitlab.com/daverona-env/pre-commit-cpp


### PR DESCRIPTION
pre-commit-cpp provides two hooks:

* cpplint: style-error detector for Google C++ Style Guide
* cppcheck: static analyzer of C/C++ code