### PR TITLE
Add cmake-format to list of all hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -101,3 +101,5 @@
 - https://github.com/codingjoe/relint
 - https://github.com/nix-community/nixpkgs-fmt
 - https://github.com/d6e/beancount-check
+- https://github.com/iconmaster5326/cmake-format-pre-commit-hook
+

--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -102,4 +102,3 @@
 - https://github.com/nix-community/nixpkgs-fmt
 - https://github.com/d6e/beancount-check
 - https://github.com/iconmaster5326/cmake-format-pre-commit-hook
-


### PR DESCRIPTION
This MR adds [cmake-format-pre-commit-hook](https://github.com/iconmaster5326/cmake-format-pre-commit-hook) to the list of all hooks.

It is a hook to run [cmake-format](https://pypi.org/project/cmake-format/) on CMake files.

EDIT: I understand that there is a MR in the works in cmake-format itself to add this support. I heavily doubt that this MR will ever be merged, however, so I recommend accepting this MR over #235. It seems the owner of cmake-format isn't too keen on adding this hook, which is a shame.