### PR TITLE
Add pre-commit hook for lisp-format

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -105,3 +105,4 @@
 - https://github.com/thg-consulting/inspectortiger
 - https://gitlab.com/iamlikeme/nbhooks
 - https://github.com/Kuniwak/vint
+- https://github.com/eschulte/lisp-format


### PR DESCRIPTION
lisp-format is a tool for autoformatting of Common Lisp code. I helped make the hook for that repo, so I thought I'd update the website here.