### PR TITLE
Add gitlab-ci-linter

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -109,3 +109,4 @@
 - https://github.com/ryanrhee/shellcheck-py
 - https://github.com/APIDevTools/swagger-cli
 - https://github.com/kynan/nbstripout
+- https://gitlab.com/devopshq/gitlab-ci-linter


### PR DESCRIPTION
We also have `check-gitlab-ci` in https://gitlab.com/smop/pre-commit-hooks, it's have external dependencies - `jq, curl`. 

New version `gitlab-ci-linter` is a pure-python script without external dependencies