### PR TITLE
Autoupdate pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,31 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+    rev: v2.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: debug-statements
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.1
+    rev: 3.7.9
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4.3
+    rev: v1.4.4
     hooks:
     -   id: autopep8
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.3.5
+    rev: v1.8.0
     hooks:
     -   id: reorder-python-imports
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.11.1
+    rev: v1.25.2
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
         exclude: ^install-local.py$
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.660
+    rev: v0.761
     hooks:
     -   id: mypy
         exclude: ^install-local.py$


### PR DESCRIPTION
mypy 0.660 does not support python 3.8 so the hook was failing to install.

This PR does `pre-commit autoupdate && pre-commit run --all` (all checks passed with the new hook versions).