### PR TITLE
Updated link from daverona-env/pre-commit-cpp to toscana/pre-commit-cpp

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -98,7 +98,7 @@
 - https://github.com/myint/docformatter
 - https://github.com/lorenzwalthert/pre-commit-hooks
 - https://github.com/FelixSeptem/pre-commit-golang
-- https://gitlab.com/daverona-env/pre-commit-cpp
+- https://gitlab.com/toscana/pre-commit-cpp
 - https://github.com/codingjoe/relint
 - https://github.com/nix-community/nixpkgs-fmt
 - https://github.com/d6e/beancount-check


### PR DESCRIPTION
My hook was registered already and I just changed the source repo of the hook.
Please merge.
Thanks a lot.