### PR TITLE
Add custom gradle hooks repository

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -115,3 +115,4 @@
 - https://github.com/igorshubovych/markdownlint-cli
 - https://github.com/TekWizely/pre-commit-golang
 - https://github.com/markdownlint/markdownlint
+- https://github.com/jguttman94/pre-commit-gradle


### PR DESCRIPTION
Created a custom pre-commit hook that allows users to perform common gradle tasks on their java projects. Includes a hook (`gradle-other`) that allows execution of any task using arguments.