### PR TITLE
Updated link from toscana/pre-commit-cpp to daverona/pre-commit-cpp

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -98,7 +98,7 @@
 - https://github.com/myint/docformatter
 - https://github.com/lorenzwalthert/pre-commit-hooks
 - https://github.com/FelixSeptem/pre-commit-golang
-- https://gitlab.com/toscana/pre-commit-cpp
+- https://gitlab.com/daverona/pre-commit-cpp
 - https://github.com/codingjoe/relint
 - https://github.com/nix-community/nixpkgs-fmt
 - https://github.com/d6e/beancount-check


### PR DESCRIPTION
Sorry to keep bothering you, but the gitlab link for pre-commit-cpp is changed. 
Please merge this fork.
Thank you. :-)