### PR TITLE
Add pre-commit badge to docs

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -1429,29 +1429,38 @@ default_language_version:
     ruby: 2.1.5
 ```
 
-## Adding the pre-commit badge
+## badging your repository
 
-If you like you can add the pre-commit badge to your documentation:
+you can add a badge to your repository to show your contributors / users that
+you use pre-commit!
+
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 - Markdown:
-    ```md
-    [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-    ```
-- HTML:
-    ```html
-    <a href="https://github.com/pre-commit/pre-commit"><img src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white" alt="pre-commit" style="max-width:100%;"></a>
-    ```
-- reStructuredText:
-    ```rst
-    .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
-       :target: https://github.com/pre-commit/pre-commit
-       :alt: pre-commit
-    ```
-- AsciiDoc:
-    ```
-    image:https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white[pre-commit, link=https://github.com/pre-commit/pre-commit]
-    ```
 
+  ```md
+  [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+  ```
+
+- HTML:
+
+  ```html
+  <a href="https://github.com/pre-commit/pre-commit"><img src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white" alt="pre-commit" style="max-width:100%;"></a>
+  ```
+
+- reStructuredText:
+
+  ```rst
+  .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
+     :target: https://github.com/pre-commit/pre-commit
+     :alt: pre-commit
+  ```
+
+- AsciiDoc:
+
+  ```
+  image:https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white[pre-commit, link=https://github.com/pre-commit/pre-commit]
+  ```
 
 ## Usage in continuous integration
 

--- a/index.mako
+++ b/index.mako
@@ -1429,6 +1429,30 @@ default_language_version:
     ruby: 2.1.5
 ```
 
+## Adding the pre-commit badge
+
+If you like you can add the pre-commit badge to your documentation:
+
+- Markdown:
+    ```md
+    [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+    ```
+- HTML:
+    ```html
+    <a href="https://github.com/pre-commit/pre-commit"><img src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white" alt="pre-commit" style="max-width:100%;"></a>
+    ```
+- reStructuredText:
+    ```rst
+    .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
+       :target: https://github.com/pre-commit/pre-commit
+       :alt: pre-commit
+    ```
+- AsciiDoc:
+    ```
+    image:https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white[pre-commit, link=https://github.com/pre-commit/pre-commit]
+    ```
+
+
 ## Usage in continuous integration
 
 pre-commit can also be used as a tool for continuous integration.  For

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -145,9 +145,7 @@ h1,
 }
 
 // vs.css: https://github.com/richleland/pygments-css
-.highlight.yaml,
-.highlight.ini,
-.highlight.bash {
+.highlight {
     .hll { background-color: #ffc; }
     .c { color: #008000; } /* Comment */
     .err { border: 1px solid #ff0; } /* Error */
@@ -197,6 +195,11 @@ h1,
     .-Color-Black-BGYellow { background-color: #c4a000; color: #2e3436; }
     .-Color-Black-BGCyan { background-color: #06989a; color: #2e3436; }
     .-Color-Faint { color: #ccc; }
+
+    .c1 { color: #06989a; }
+    .s { color: #8ae234; }
+    .s1 { color: #8ae234; }
+    .s2 { color: #8ae234; }
 }
 
 @media (max-width: $screen-md-max) {


### PR DESCRIPTION
Please preview the mako and see if it looks good. Not sure how to do this on my end on the fly. In GH Markdown you can have indented code blocks in (numbered) lists:

- First
    ```sh
    cat ~/test.txt
    ```
- Second
    ```sh
    cat ~/test.txt
    ```
- Unindented
```sh
cat ~/test.txt
```