### PR TITLE
kustomize pre-commit hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -117,3 +117,4 @@
 - https://github.com/markdownlint/markdownlint
 - https://github.com/jguttman94/pre-commit-gradle
 - https://github.com/Yelp/detect-secrets
+- https://github.com/dmitri-lerko/pre-commit-docker-kustomize


### PR DESCRIPTION
This adds a kustomize pre-commit hook that can be used to validate that [kustomize](https://github.com/kubernetes-sigs/kustomize) overlays are not broken by the changes.

Please let me know if I am missing something.