### PR TITLE
Add Talos's Conform policy enforcement hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -119,3 +119,4 @@
 - https://github.com/Yelp/detect-secrets
 - https://github.com/dmitri-lerko/pre-commit-docker-kustomize
 - https://github.com/perltidy/perltidy
+- https://github.com/talos-systems/conform


### PR DESCRIPTION
This is a system for enforcing policies in a repository, including (among other things) the [Conventional Commit standard](https://www.conventionalcommits.org/en/v1.0.0/).