### PR TITLE
add note about required arg for {prepare-}commit-msg

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -488,6 +488,9 @@ directory while developing hooks.
 enabling a quick way to try out a repository.  Here's how one might work
 interactively:
 
+_note_: you may need to provide `--commit-msg-filename` when using this
+command with hook types `prepare-commit-msg` and `commit-msg`.
+
 _new in 1.14.0_: a commit is no longer necessary to `try-repo` on a local
 directory. `pre-commit` will clone any uncommitted changes.
 


### PR DESCRIPTION
Since `--commit-msg-filename` is required when using prepare-commit-msg and commit-msg for things like `try-repo`, just making a note of that in the docs.