### PR TITLE
Give an example of how to force flake8 to use a specific python version.

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -1202,6 +1202,7 @@ as follows:
     hooks:
     -   id: flake8
         args: [--max-line-length=131]
+        language_version: python3.8
 ```
 
 This will pass `--max-line-length=131` to `flake8`.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/229453/77157737-3e424c80-6aa2-11ea-8965-19c905ddfe66.png)

As flake8 documentation states, it might be interesting to tell people to set the version they want to target.