### PR TITLE
Renamed repo

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -96,7 +96,7 @@
 - https://github.com/seddonym/import-linter
 - https://github.com/marco-c/taskcluster_yml_validator
 - https://github.com/myint/docformatter
-- https://github.com/lorenzwalthert/pre-commit-hooks
+- https://github.com/lorenzwalthert/precommit
 - https://github.com/FelixSeptem/pre-commit-golang
 - https://gitlab.com/daverona/pre-commit-cpp
 - https://github.com/codingjoe/relint


### PR DESCRIPTION
I renamed my pre-commit hook repo to give the repo the same name as the [R package](https://github.com/lorenzwalthert/precommit) (dashes not permitted). I promise to adhere to the spelling *pre-commit* whenever possible and I use *precommit* otherwise :smile:. 