### PR TITLE
Revert "Fix broken build" due to detect-secrets

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -117,6 +117,7 @@
 - https://github.com/TekWizely/pre-commit-golang
 - https://github.com/markdownlint/markdownlint
 - https://github.com/jguttman94/pre-commit-gradle
+- https://github.com/Yelp/detect-secrets
 - https://github.com/dmitri-lerko/pre-commit-docker-kustomize
 - https://github.com/perltidy/perltidy
 - https://github.com/talos-systems/conform


### PR DESCRIPTION
This reverts commit 81fa5ad355aff71a5426ca5ffc06598b1549f0bc.

Detect-secrets commit https://github.com/Yelp/detect-secrets/commit/00b9bf8dd035fd8046bb41be1efc907c13646fd5 broke things, and is now fixed.