### PR TITLE
Add mathieu-lemay/pre-commit-rust

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -131,3 +131,4 @@
 - https://github.com/jazzband/pip-tools
 - https://github.com/pappasam/toml-sort
 - https://github.com/arenadotio/pre-commit-ocamlformat
+- https://github.com/mathieu-lemay/pre-commit-rust


### PR DESCRIPTION
This is a modified version of doublify/pre-commit-rust which replaces `rustfmt` by `cargo fmt`, the new standard tool for formatting. 
I opened a PR to them [here](https://github.com/doublify/pre-commit-rust/pull/6) but there doesn't seem to be any interest in merging it so I figured I'd add my hooks here.